### PR TITLE
Refactor email handling to support Microsoft Graph and OAuth delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,44 +113,59 @@ Member Voting is a secure, timezone-aware web application for managing ballots, 
 - Request/renew HTTPS certificates and rebuild Nginx config from the Branding page
 - All settings are stored in the database and applied dynamically
 
-## Email Invites for Registration & SMTP/OAuth
+## Email invites and delivery options
 
-The app supports sending unique, expiring registration links that allow sign-ups even when global registration is disabled.
+The app can send unique, expiring registration links (even when global registration is disabled). You can choose between three delivery methods in the Admin UI.
 
-1. Configure email delivery
-   - In the Admin UI → Branding → SMTP Settings:
-     - Option A: Basic SMTP (URL or host/port/TLS/username/password)
-     - Option B: OAuth (Exchange Online)
-       - Toggle "Use OAuth (Exchange Online)" and supply:
-         - Tenant ID, Client ID, Client Secret (stored securely, masked in UI)
-         - OAuth User (the mailbox email to send from)
-         - Optional: Scope (default `https://outlook.office365.com/.default`), Authority (default `https://login.microsoftonline.com`)
-       - Click "Verify OAuth Token" to ensure MSAL token acquisition is working
-       - Use "Send Test Email" to confirm mail delivery
-   - Server env fallback (if DB settings not provided):
-     - `SMTP_URL` OR the following individual settings:
-       - `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE` (true/false), `SMTP_USER`, `SMTP_PASS`
-     - Optional: `FROM_EMAIL` (default `no-reply@member-voting`)
+1) Microsoft Graph (app-only, recommended for service accounts)
+- Admin UI → Branding → Email Settings → enable "Use Microsoft Graph"
+- Fill these fields and Save:
+  - Tenant ID, Client ID, Client Secret (masked when saved)
+  - Send As (user email), Authority (default OK)
+- Click "Verify OAuth Token" to validate Graph credentials
+- Use "Send Test Email" to confirm delivery
 
-2. In the Admin UI (Members page):
-  - Create invites with an optional email, count, and expiration window
-  - Copy the invite link or click "Send Email" to email it to the invitee
+Azure requirements:
+- Azure AD App Registration with Application permission Mail.Send (admin consent)
+- After consent, the app can send mail using the selected "Send As" user
 
-3. Registration Page Behavior:
-  - When a user visits `/register?invite=TOKEN`, the app validates the token
-  - If registration is globally disabled, a valid invite still allows registration
-  - If the invite has an email, the username field is prefilled and locked to that email
+2) SMTP with delegated OAuth (Exchange Online)
+- Admin UI → Branding → Email Settings → enable "Use OAuth (Exchange Online)"
+- Set Mode = Delegated (device code)
+- Fill and Save:
+  - Tenant ID, Client ID, OAuth User (mailbox email)
+  - Scopes (default includes `https://outlook.office365.com/SMTP.Send offline_access openid profile email`)
+  - Authority (default OK)
+- Click "Start Device Code Sign-in" and follow the on-screen instructions to authenticate the mailbox user
+- Click "Verify OAuth Token" to confirm delegated token availability
+- Use "Send Test Email"
 
-### Exchange Online (OAuth) setup notes
+Notes:
+- SMTP with app-only OAuth is not supported by Exchange Online; use delegated mode or Microsoft Graph
+- MSAL token cache is persisted in the `settings` table and refreshed automatically
 
-To use OAuth with Exchange Online SMTP:
+3) SMTP with basic auth
+- Admin UI → Branding → Email Settings (leave OAuth and Graph disabled)
+- Provide SMTP URL, or Host/Port/Secure/Username/Password
+- Save and send a test email
+- Tenant/mailbox must have SMTP AUTH enabled for this to work
 
-- Create an Azure AD App Registration and enable client credentials (Client Secret).
-- Grant application permissions that back the `https://outlook.office365.com/.default` resource (requires admin consent).
-- Ensure SMTP AUTH is enabled in your tenant and for the mailbox if applicable.
-- The mailbox specified in "OAuth User" must be accessible to the app under your org’s security model.
+Server env fallback (if DB settings are not set):
+- `SMTP_URL` OR individual settings: `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE` (true/false), `SMTP_USER`, `SMTP_PASS`
+- Optional: `FROM_EMAIL` (default `no-reply@member-voting`)
 
-Troubleshooting: Use the "Verify OAuth Token" button to get immediate feedback. The UI will surface MSAL error details (code/suberror/correlation ID) to help pinpoint configuration issues.
+### Sending invites
+- In the Admin UI (Members/Invites), create invite(s) with optional email and expiration
+- Copy the link or click "Send Email" to email it directly
+
+### Registration behavior
+- Visiting `/register?invite=TOKEN` validates the token and permits sign-up even if global registration is disabled
+- If the invite includes an email, the username is pre-filled and locked
+
+### Troubleshooting
+- Use "Verify OAuth Token" for immediate feedback:
+  - Reports if delegated OAuth (SMTP) or Graph (app-only) is configured correctly
+  - Surfaces MSAL error details to help diagnose setup issues
 
 ## Support
 For issues or feature requests, open an issue on GitHub or contact the maintainer.

--- a/backend/email.js
+++ b/backend/email.js
@@ -1,0 +1,301 @@
+const nodemailer = require('nodemailer');
+const { ConfidentialClientApplication, PublicClientApplication } = require('@azure/msal-node');
+
+// Keys we read frequently
+const BASE_SMTP_KEYS = [
+  'smtp_url', 'smtp_host', 'smtp_port', 'smtp_secure', 'smtp_user', 'smtp_pass', 'from_email',
+  'oauth_enabled', 'oauth_mode', 'oauth_tenant_id', 'oauth_client_id', 'oauth_client_secret', 'oauth_user', 'oauth_scope', 'oauth_authority'
+];
+const GRAPH_KEYS = [
+  'use_graph_email', 'graph_tenant_id', 'graph_client_id', 'graph_client_secret', 'graph_user', 'graph_authority'
+];
+
+async function readSettingsMap(pool, keys) {
+  const map = {};
+  try {
+    const res = await pool.query(`SELECT key, value FROM settings WHERE key = ANY($1)`, [keys]);
+    for (const row of res.rows) map[row.key] = row.value;
+  } catch (e) {
+    // ignore; return empty defaults
+  }
+  return map;
+}
+
+function flag(val) {
+  return String(val || '').toLowerCase() === 'true';
+}
+
+function getAuthority(authorityBase, tenantId) {
+  const base = (authorityBase || 'https://login.microsoftonline.com').trim();
+  const tenant = (tenantId || 'common').trim();
+  return `${base}/${tenant}`;
+}
+
+// MSAL cache plugin backed by settings table under a given key
+function createDbCachePlugin(pool, settingsKey) {
+  return {
+    beforeCacheAccess: async (cacheContext) => {
+      try {
+        const res = await pool.query(`SELECT value FROM settings WHERE key = $1`, [settingsKey]);
+        const json = res.rows[0]?.value || '';
+        if (json) {
+          await cacheContext.tokenCache.deserialize(json);
+        }
+      } catch (e) {
+        // ignore
+      }
+    },
+    afterCacheAccess: async (cacheContext) => {
+      if (cacheContext.cacheHasChanged) {
+        try {
+          const json = await cacheContext.tokenCache.serialize();
+          await pool.query(
+            `INSERT INTO settings(key, value) VALUES($1, $2)
+             ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value`,
+            [settingsKey, json]
+          );
+        } catch (e) {
+          // ignore
+        }
+      }
+    },
+  };
+}
+
+async function acquireGraphAppToken(pool, settings) {
+  const tenantId = (settings.graph_tenant_id || settings.oauth_tenant_id || '').trim();
+  const clientId = (settings.graph_client_id || settings.oauth_client_id || '').trim();
+  const clientSecret = (settings.graph_client_secret || settings.oauth_client_secret || '').trim();
+  const authorityBase = (settings.graph_authority || settings.oauth_authority || 'https://login.microsoftonline.com').trim();
+  if (!tenantId || !clientId || !clientSecret) {
+    throw new Error('Graph app settings missing (tenantId, clientId, or clientSecret).');
+  }
+  const cca = new ConfidentialClientApplication({
+    auth: {
+      clientId,
+      clientSecret,
+      authority: getAuthority(authorityBase, tenantId),
+    },
+  });
+  const token = await cca.acquireTokenByClientCredential({ scopes: ['https://graph.microsoft.com/.default'] });
+  if (!token?.accessToken) throw new Error('Failed to acquire Graph access token.');
+  return token.accessToken;
+}
+
+async function sendViaGraph(pool, settings, msg) {
+  const accessToken = await acquireGraphAppToken(pool, settings);
+  const user = (settings.graph_user || settings.oauth_user || '').trim();
+  if (!user) throw new Error('Graph user (sender) not configured.');
+  const fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+  const url = `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(user)}/sendMail`;
+  const body = {
+    message: {
+      subject: msg.subject || '',
+      body: {
+        contentType: msg.html ? 'HTML' : 'Text',
+        content: msg.html || msg.text || '',
+      },
+      toRecipients: (Array.isArray(msg.to) ? msg.to : [msg.to]).filter(Boolean).map(t => ({ emailAddress: { address: t } })),
+      // Do not set 'from' explicitly; Graph will send as the path user
+    },
+    saveToSentItems: true,
+  };
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Graph sendMail failed (${resp.status}): ${text}`);
+  }
+  return { success: true };
+}
+
+async function acquireDelegatedSmtpToken(pool, settings) {
+  const tenantId = (settings.oauth_tenant_id || '').trim();
+  const clientId = (settings.oauth_client_id || '').trim();
+  const authorityBase = (settings.oauth_authority || 'https://login.microsoftonline.com').trim();
+  if (!tenantId || !clientId) throw new Error('Delegated OAuth settings missing (tenantId or clientId).');
+  const cachePlugin = createDbCachePlugin(pool, 'smtp_oauth_cache');
+  const pca = new PublicClientApplication({
+    auth: { clientId, authority: getAuthority(authorityBase, tenantId) },
+    cache: { cachePlugin },
+  });
+  const scopes = (settings.oauth_scope && settings.oauth_scope.trim())
+    ? settings.oauth_scope.trim().split(/[\s,]+/)
+    : ['offline_access', 'openid', 'profile', 'email', 'https://outlook.office365.com/SMTP.Send'];
+
+  // Try silent first using cached account; prefer settings.oauth_user
+  const cache = pca.getTokenCache();
+  const accounts = await cache.getAllAccounts();
+  let account = null;
+  const preferred = (settings.oauth_user || '').toLowerCase();
+  if (preferred) {
+    account = accounts.find(a => (a.username || '').toLowerCase() === preferred);
+  }
+  if (!account && accounts.length > 0) account = accounts[0];
+  if (!account) {
+    throw new Error('No delegated OAuth account found. Run the device code flow to sign in.');
+  }
+  const token = await pca.acquireTokenSilent({ account, scopes });
+  if (!token?.accessToken) throw new Error('Failed to acquire delegated access token silently.');
+  return { accessToken: token.accessToken, username: account.username };
+}
+
+async function createSmtpTransportFromSettings(settings, delegatedToken) {
+  // Priority: smtp_url -> host config
+  if (settings.smtp_url && settings.smtp_url.trim()) {
+    return nodemailer.createTransport(settings.smtp_url.trim());
+  }
+  const host = (settings.smtp_host || '').trim();
+  if (!host) return nodemailer.createTransport({ jsonTransport: true });
+  const port = Number(settings.smtp_port || '587');
+  const secure = flag(settings.smtp_secure);
+  const base = {
+    host,
+    port: isNaN(port) ? 587 : port,
+    secure,
+  };
+  if (delegatedToken && settings.oauth_user) {
+    return nodemailer.createTransport({
+      ...base,
+      requireTLS: !secure,
+      auth: {
+        type: 'OAuth2',
+        user: settings.oauth_user,
+        accessToken: delegatedToken,
+      },
+    });
+  }
+  const user = (settings.smtp_user || '').trim();
+  const pass = (settings.smtp_pass || '').trim();
+  return nodemailer.createTransport({
+    ...base,
+    auth: user ? { user, pass } : undefined,
+  });
+}
+
+async function sendViaSmtp(pool, settings, msg) {
+  let delegated = false;
+  let accessToken = null;
+  if (flag(settings.oauth_enabled)) {
+    const mode = (settings.oauth_mode || '').toLowerCase();
+    const clientSecretPresent = !!(settings.oauth_client_secret && settings.oauth_client_secret.trim());
+    // Prefer delegated if mode says so, or when no client secret is present.
+    if (mode === 'delegated' || !clientSecretPresent) {
+      const token = await acquireDelegatedSmtpToken(pool, settings);
+      accessToken = token.accessToken;
+      delegated = true;
+    } else {
+      // Note: App-only tokens do NOT work with SMTP AUTH XOAUTH2. We warn and fall back.
+      throw new Error('SMTP with app-only OAuth is not supported by Exchange Online. Enable delegated OAuth (device code) or use Microsoft Graph.');
+    }
+  }
+  const transporter = await createSmtpTransportFromSettings(settings, delegated ? accessToken : null);
+  const info = await transporter.sendMail({
+    from: msg.from,
+    to: msg.to,
+    subject: msg.subject,
+    text: msg.text,
+    html: msg.html,
+  });
+  return { success: true, messageId: info?.messageId };
+}
+
+async function sendEmail(pool, message) {
+  const settings = {
+    ...(await readSettingsMap(pool, [...BASE_SMTP_KEYS, ...GRAPH_KEYS])),
+  };
+  const useGraph = flag(settings.use_graph_email);
+  // Determine from email default
+  const fromEmail = settings.from_email || process.env.FROM_EMAIL || 'no-reply@member-voting';
+  const msg = { ...message, from: message.from || fromEmail };
+  if (useGraph) return sendViaGraph(pool, settings, msg);
+  return sendViaSmtp(pool, settings, msg);
+}
+
+// Start Device Code flow (delegated SMTP). Returns device code details immediately and completes in background.
+async function startDelegatedDeviceCodeFlow(pool) {
+  const settings = await readSettingsMap(pool, BASE_SMTP_KEYS);
+  const tenantId = (settings.oauth_tenant_id || '').trim();
+  const clientId = (settings.oauth_client_id || '').trim();
+  const authorityBase = (settings.oauth_authority || 'https://login.microsoftonline.com').trim();
+  if (!tenantId || !clientId) throw new Error('Missing OAuth settings (tenant id, client id).');
+  const cachePlugin = createDbCachePlugin(pool, 'smtp_oauth_cache');
+  const pca = new PublicClientApplication({
+    auth: { clientId, authority: getAuthority(authorityBase, tenantId) },
+    cache: { cachePlugin },
+  });
+  const scopes = (settings.oauth_scope && settings.oauth_scope.trim())
+    ? settings.oauth_scope.trim().split(/[\s,]+/)
+    : ['offline_access', 'openid', 'profile', 'email', 'https://outlook.office365.com/SMTP.Send'];
+
+  let deviceInfo = null;
+  // Kick off flow and return device code right away
+  const promise = pca.acquireTokenByDeviceCode({
+    scopes,
+    deviceCodeCallback: (info) => { deviceInfo = info; },
+  })
+    .then(async (resp) => {
+      // Persist preferred oauth_user
+      const username = resp?.account?.username || '';
+      if (username) {
+        await pool.query(
+          `INSERT INTO settings(key, value) VALUES('oauth_user', $1)
+           ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value`,
+          [username]
+        );
+      }
+      return resp;
+    })
+    .catch((err) => {
+      // Log; nothing else
+      console.error('Device code flow failed:', err?.message || err);
+    });
+  // Store device code details for UI convenience
+  if (deviceInfo) {
+    try {
+      const payload = JSON.stringify({
+        userCode: deviceInfo.userCode,
+        verificationUri: deviceInfo.verificationUri || deviceInfo.verificationUriComplete,
+        message: deviceInfo.message,
+        expiresOn: deviceInfo.expiresOn,
+      });
+      await pool.query(
+        `INSERT INTO settings(key, value) VALUES('smtp_device_code_info', $1)
+         ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value`,
+        [payload]
+      );
+    } catch {}
+  }
+  return { started: true, device: deviceInfo || null };
+}
+
+module.exports = {
+  sendEmail,
+  startDelegatedDeviceCodeFlow,
+  // Helper to check delegated token availability without exposing token
+  tryDelegatedSmtpSilent: async (pool) => {
+    const settings = await readSettingsMap(pool, BASE_SMTP_KEYS);
+    try {
+      const { accessToken, username } = await acquireDelegatedSmtpToken(pool, settings);
+      return { success: !!accessToken, username: username || settings.oauth_user || '' };
+    } catch (e) {
+      return { success: false, error: e?.message };
+    }
+  },
+  // Helper to verify Graph app-only auth
+  verifyGraphAuth: async (pool) => {
+    const settings = await readSettingsMap(pool, [...BASE_SMTP_KEYS, ...GRAPH_KEYS]);
+    try {
+      await acquireGraphAppToken(pool, settings);
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: e?.message };
+    }
+  },
+};

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -12,6 +12,7 @@ const { X509Certificate } = require('crypto');
 const { setRegistrationEnabled, getRegistrationEnabled } = require('./db');
 const crypto = require('crypto');
 const nodemailer = require('nodemailer');
+const emailSvc = require('./email');
 const { DateTime } = require('luxon');
 
 // Auth routes
@@ -51,12 +52,12 @@ router.get('/certificate-status', (req, res) => {
   }
 });
 
-// Helper: read SMTP settings from DB settings table and build transporter
+// Helper: read SMTP settings from DB settings table and build transporter (basic/env only)
 async function createSmtpTransport(pool) {
   // Read settings keys
   const keys = [
     'smtp_url', 'smtp_host', 'smtp_port', 'smtp_secure', 'smtp_user', 'smtp_pass',
-    // OAuth keys
+    // legacy OAuth keys ignored here; OAuth handled in email service
     'oauth_enabled', 'oauth_tenant_id', 'oauth_client_id', 'oauth_client_secret', 'oauth_user', 'oauth_scope', 'oauth_authority'
   ];
   let settingsMap = {};
@@ -65,50 +66,6 @@ async function createSmtpTransport(pool) {
     for (const row of res.rows) settingsMap[row.key] = row.value;
   } catch (e) {
     // fallback to env if settings table inaccessible
-  }
-
-  // OAuth (Exchange Online) path
-  const oauthEnabled = String(settingsMap.oauth_enabled || '').toLowerCase() === 'true';
-  if (oauthEnabled) {
-    const tenantId = (settingsMap.oauth_tenant_id || '').trim();
-    const clientId = (settingsMap.oauth_client_id || '').trim();
-    const clientSecret = settingsMap.oauth_client_secret || '';
-    const user = (settingsMap.oauth_user || '').trim();
-    const scope = (settingsMap.oauth_scope || 'https://outlook.office365.com/.default').trim();
-    const authorityBase = (settingsMap.oauth_authority || 'https://login.microsoftonline.com').trim();
-    if (!tenantId || !clientId || !clientSecret || !user) {
-      throw new Error('OAuth is enabled but required fields are missing (tenant id, client id, client secret, user).');
-    }
-    // Host/port defaults for Exchange Online if not specified
-    const host = (settingsMap.smtp_host || 'smtp.office365.com').trim();
-    const port = Number(settingsMap.smtp_port || '587');
-    const secure = String(settingsMap.smtp_secure || '').toLowerCase() === 'true';
-
-    // Acquire token using MSAL (client credential flow)
-    const { ConfidentialClientApplication } = require('@azure/msal-node');
-    const cca = new ConfidentialClientApplication({
-      auth: {
-        clientId,
-        authority: `${authorityBase}/${tenantId}`,
-        clientSecret,
-      },
-    });
-    const tokenResponse = await cca.acquireTokenByClientCredential({ scopes: [scope] });
-    if (!tokenResponse || !tokenResponse.accessToken) {
-      throw new Error('Failed to acquire OAuth access token for SMTP.');
-    }
-    const accessToken = tokenResponse.accessToken;
-    return nodemailer.createTransport({
-      host,
-      port: isNaN(port) ? 587 : port,
-      secure,
-      requireTLS: !secure,
-      auth: {
-        type: 'OAuth2',
-        user,
-        accessToken,
-      },
-    });
   }
 
   // Priority: smtp_url -> host config -> env -> JSON transport
@@ -527,18 +484,8 @@ router.post('/invites/:id/send', authenticateToken, requireAdmin, async (req, re
     const proto = (process.env.NODE_ENV === 'production') ? 'https' : 'http';
     const port = process.env.FRONTEND_PORT || (proto === 'http' ? ':5173' : '');
     const url = `${proto}://${fqdn}${port}/register?invite=${invite.token}`;
-    // Configure transporter (DB settings preferred, then env, else JSON)
-    const transporter = await createSmtpTransport(pool);
-
-    // From email preference: settings.from_email -> env FROM_EMAIL -> default
-    let fromEmail = process.env.FROM_EMAIL || 'no-reply@member-voting';
-    try {
-      const fromRes = await pool.query(`SELECT value FROM settings WHERE key = 'from_email'`);
-      if (fromRes.rows[0]?.value) fromEmail = fromRes.rows[0].value;
-    } catch (e) {}
-
-    const sendRes = await transporter.sendMail({
-      from: fromEmail,
+    // Unified email send (Graph or SMTP)
+    const sendRes = await emailSvc.sendEmail(pool, {
       to: invite.email,
       subject: 'Your registration link',
       text: `You have been invited to register. Use this link: ${url}\nThis link expires at ${new Date(invite.expires_at).toLocaleString()}.`,
@@ -582,13 +529,16 @@ router.get('/smtp-settings', authenticateToken, requireAdmin, async (req, res) =
     const pool = req.pool;
     const keys = [
       'smtp_url', 'smtp_host', 'smtp_port', 'smtp_secure', 'smtp_user', 'smtp_pass', 'from_email',
-      'oauth_enabled', 'oauth_tenant_id', 'oauth_client_id', 'oauth_client_secret', 'oauth_user', 'oauth_scope', 'oauth_authority'
+      'oauth_enabled', 'oauth_mode', 'oauth_tenant_id', 'oauth_client_id', 'oauth_client_secret', 'oauth_user', 'oauth_scope', 'oauth_authority',
+      'use_graph_email', 'graph_tenant_id', 'graph_client_id', 'graph_client_secret', 'graph_user', 'graph_authority'
     ];
     const result = await pool.query(`SELECT key, value FROM settings WHERE key = ANY($1)`, [keys]);
     const out = {
       smtp_url: '', smtp_host: '', smtp_port: '', smtp_secure: false, smtp_user: '', smtp_pass: '', has_password: false, from_email: '',
-      oauth_enabled: false, oauth_tenant_id: '', oauth_client_id: '', oauth_client_secret: '', oauth_user: '', oauth_scope: 'https://outlook.office365.com/.default', oauth_authority: 'https://login.microsoftonline.com',
+      oauth_enabled: false, oauth_mode: 'delegated', oauth_tenant_id: '', oauth_client_id: '', oauth_client_secret: '', oauth_user: '', oauth_scope: 'https://outlook.office365.com/SMTP.Send offline_access openid profile email', oauth_authority: 'https://login.microsoftonline.com',
       has_client_secret: false,
+      use_graph_email: false, graph_tenant_id: '', graph_client_id: '', graph_client_secret: '', graph_user: '', graph_authority: 'https://login.microsoftonline.com',
+      has_graph_client_secret: false,
     };
     for (const row of result.rows) {
       if (row.key === 'smtp_secure') {
@@ -597,17 +547,24 @@ router.get('/smtp-settings', authenticateToken, requireAdmin, async (req, res) =
         out.has_password = !!row.value;
       } else if (row.key === 'oauth_enabled') {
         out.oauth_enabled = String(row.value).toLowerCase() === 'true';
+      } else if (row.key === 'oauth_mode') {
+        out.oauth_mode = (row.value || 'delegated');
       } else if (row.key === 'oauth_client_secret') {
         out.has_client_secret = !!row.value;
       } else if (row.key in out) {
         out[row.key] = row.value || '';
       } else if (row.key === 'from_email') {
         out.from_email = row.value || '';
+      } else if (row.key === 'use_graph_email') {
+        out.use_graph_email = String(row.value).toLowerCase() === 'true';
+      } else if (row.key === 'graph_client_secret') {
+        out.has_graph_client_secret = !!row.value;
       }
     }
     // Do not return actual password; indicate if present
     out.smtp_pass = '';
     out.oauth_client_secret = '';
+    out.graph_client_secret = '';
     res.json(out);
   } catch (err) {
     res.status(500).json({ error: 'Failed to load SMTP settings' });
@@ -620,7 +577,8 @@ router.put('/smtp-settings', authenticateToken, requireAdmin, async (req, res) =
     const pool = req.pool;
     const {
       smtp_url, smtp_host, smtp_port, smtp_secure, smtp_user, smtp_pass, from_email, clear_password,
-      oauth_enabled, oauth_tenant_id, oauth_client_id, oauth_client_secret, oauth_user, oauth_scope, oauth_authority, clear_client_secret
+      oauth_enabled, oauth_mode, oauth_tenant_id, oauth_client_id, oauth_client_secret, oauth_user, oauth_scope, oauth_authority, clear_client_secret,
+      use_graph_email, graph_tenant_id, graph_client_id, graph_client_secret, graph_user, graph_authority, clear_graph_client_secret
     } = req.body || {};
     // Helper to upsert key/value
     async function upsert(key, value) {
@@ -645,6 +603,7 @@ router.put('/smtp-settings', authenticateToken, requireAdmin, async (req, res) =
 
     // OAuth fields
     if (oauth_enabled !== undefined) await upsert('oauth_enabled', String(!!oauth_enabled));
+    if (typeof oauth_mode === 'string') await upsert('oauth_mode', oauth_mode.trim());
     if (typeof oauth_tenant_id === 'string') await upsert('oauth_tenant_id', oauth_tenant_id.trim());
     if (typeof oauth_client_id === 'string') await upsert('oauth_client_id', oauth_client_id.trim());
     if (typeof oauth_user === 'string') await upsert('oauth_user', oauth_user.trim());
@@ -654,6 +613,18 @@ router.put('/smtp-settings', authenticateToken, requireAdmin, async (req, res) =
       await upsert('oauth_client_secret', '');
     } else if (typeof oauth_client_secret === 'string' && oauth_client_secret.length > 0) {
       await upsert('oauth_client_secret', oauth_client_secret);
+    }
+
+    // Graph fields
+    if (use_graph_email !== undefined) await upsert('use_graph_email', String(!!use_graph_email));
+    if (typeof graph_tenant_id === 'string') await upsert('graph_tenant_id', graph_tenant_id.trim());
+    if (typeof graph_client_id === 'string') await upsert('graph_client_id', graph_client_id.trim());
+    if (typeof graph_user === 'string') await upsert('graph_user', graph_user.trim());
+    if (typeof graph_authority === 'string') await upsert('graph_authority', graph_authority.trim());
+    if (clear_graph_client_secret === true) {
+      await upsert('graph_client_secret', '');
+    } else if (typeof graph_client_secret === 'string' && graph_client_secret.length > 0) {
+      await upsert('graph_client_secret', graph_client_secret);
     }
 
     res.json({ success: true });
@@ -678,23 +649,14 @@ router.post('/smtp-settings/test', authenticateToken, requireAdmin, async (req, 
       return res.status(400).json({ error: 'Provide a valid test recipient email in the request body as { to }.' });
     }
 
-    const transporter = await createSmtpTransport(pool);
-    // From email preference: settings.from_email -> env FROM_EMAIL -> default
-    let fromEmail = process.env.FROM_EMAIL || 'no-reply@member-voting';
-    try {
-      const fromRes = await pool.query(`SELECT value FROM settings WHERE key = 'from_email'`);
-      if (fromRes.rows[0]?.value) fromEmail = fromRes.rows[0].value;
-    } catch (e) {}
-
     const now = new Date();
-    const info = await transporter.sendMail({
-      from: fromEmail,
+    const info = await emailSvc.sendEmail(pool, {
       to: recipient,
       subject: 'SMTP Test Email',
       text: `This is a test email from Member Voting. Sent at ${now.toISOString()}.`,
       html: `<p>This is a <b>test email</b> from Member Voting.</p><p>Sent at ${now.toISOString()}.</p>`,
     });
-    res.json({ success: true, messageId: info.messageId || undefined, envelope: info.envelope || undefined, preview: info.message || undefined });
+    res.json({ success: true, messageId: info.messageId || undefined });
   } catch (err) {
     console.error(err);
     const payload = { error: 'Failed to send test email' };
@@ -712,29 +674,12 @@ router.post('/smtp-settings/test', authenticateToken, requireAdmin, async (req, 
 router.post('/smtp-settings/verify-oauth', authenticateToken, requireAdmin, async (req, res) => {
   try {
     const pool = req.pool;
-    // Read required OAuth settings
-    const keys = ['oauth_enabled', 'oauth_tenant_id', 'oauth_client_id', 'oauth_client_secret', 'oauth_scope', 'oauth_authority'];
-    const result = await pool.query(`SELECT key, value FROM settings WHERE key = ANY($1)`, [keys]);
-    const map = {};
-    for (const row of result.rows) map[row.key] = row.value;
-    if (String(map.oauth_enabled || '').toLowerCase() !== 'true') {
-      return res.status(400).json({ error: 'OAuth is not enabled.' });
-    }
-    const tenantId = (map.oauth_tenant_id || '').trim();
-    const clientId = (map.oauth_client_id || '').trim();
-    const clientSecret = map.oauth_client_secret || '';
-    const authorityBase = (map.oauth_authority || 'https://login.microsoftonline.com').trim();
-    const scope = (map.oauth_scope || 'https://outlook.office365.com/.default').trim();
-    if (!tenantId || !clientId || !clientSecret) {
-      return res.status(400).json({ error: 'Missing OAuth settings (tenant id, client id, or client secret).' });
-    }
-    const { ConfidentialClientApplication } = require('@azure/msal-node');
-    const cca = new ConfidentialClientApplication({ auth: { clientId, authority: `${authorityBase}/${tenantId}`, clientSecret } });
-    const tokenResponse = await cca.acquireTokenByClientCredential({ scopes: [scope] });
-    if (!tokenResponse || !tokenResponse.accessToken) {
-      return res.status(500).json({ error: 'Token acquisition failed.' });
-    }
-    res.json({ success: true, expiresOn: tokenResponse.expiresOn?.toISOString?.() || tokenResponse.expiresOn || null, tokenType: tokenResponse.tokenType || 'Bearer' });
+    const { tryDelegatedSmtpSilent, verifyGraphAuth } = require('./email');
+    const del = await tryDelegatedSmtpSilent(pool);
+    if (del.success) return res.json({ success: true, mode: 'delegated', username: del.username });
+    const graph = await verifyGraphAuth(pool);
+    if (graph.success) return res.json({ success: true, mode: 'graph' });
+    return res.status(400).json({ error: 'No valid OAuth path configured', delegatedError: del.error, graphError: graph.error });
   } catch (err) {
     console.error(err);
     const payload = { error: 'OAuth verification failed' };
@@ -745,6 +690,17 @@ router.post('/smtp-settings/verify-oauth', authenticateToken, requireAdmin, asyn
       if (err.correlationId) payload.correlationId = err.correlationId;
     }
     res.status(500).json(payload);
+  }
+});
+
+// Start delegated OAuth device code flow for SMTP
+router.post('/smtp-settings/oauth/device-code', authenticateToken, requireAdmin, async (req, res) => {
+  try {
+    const pool = req.pool;
+    const result = await emailSvc.startDelegatedDeviceCodeFlow(pool);
+    res.json({ success: true, device: result.device || null });
+  } catch (err) {
+    res.status(500).json({ error: err.message || 'Failed to start device code flow' });
   }
 });
 

--- a/frontend/src/pages/BrandingPage.jsx
+++ b/frontend/src/pages/BrandingPage.jsx
@@ -20,22 +20,36 @@ export default function BrandingPage() {
     from_email: '',
     // OAuth fields
     oauth_enabled: false,
+    oauth_mode: 'delegated',
     oauth_tenant_id: '',
     oauth_client_id: '',
     oauth_client_secret: '',
     has_client_secret: false,
     oauth_user: '',
-    oauth_scope: 'https://outlook.office365.com/.default',
-    oauth_authority: 'https://login.microsoftonline.com'
+    oauth_scope: 'https://outlook.office365.com/SMTP.Send offline_access openid profile email',
+    oauth_authority: 'https://login.microsoftonline.com',
+    // Graph
+    use_graph_email: false,
+    graph_tenant_id: '',
+    graph_client_id: '',
+    graph_client_secret: '',
+    has_graph_client_secret: false,
+    graph_user: '',
+    graph_authority: 'https://login.microsoftonline.com'
   });
   const [smtpTestTo, setSmtpTestTo] = useState('');
   const isOAuthConfigured = !!smtp.oauth_enabled;
   const isOAuthValid = !isOAuthConfigured || (
     (smtp.oauth_tenant_id?.trim()?.length > 0) &&
     (smtp.oauth_client_id?.trim()?.length > 0) &&
-    ((smtp.oauth_client_secret?.trim()?.length > 0) || smtp.has_client_secret) &&
     (smtp.oauth_user?.trim()?.length > 0)
   );
+  const canSaveGraph = smtp.use_graph_email ? (
+    (smtp.graph_tenant_id?.trim()?.length > 0) &&
+    (smtp.graph_client_id?.trim()?.length > 0) &&
+    ((smtp.graph_client_secret?.trim()?.length > 0) || smtp.has_graph_client_secret) &&
+    (smtp.graph_user?.trim()?.length > 0)
+  ) : true;
 
   useEffect(() => {
     apiRequest('/branding', 'GET').then(res => {
@@ -224,8 +238,8 @@ export default function BrandingPage() {
   <button onClick={() => handleUpload('icon', iconFile)} style={{background: branding.button_color || '#007bff', color: branding.text_color || '#fff', border: 'none', borderRadius: '4px', padding: '4px 12px', marginTop: '8px'}}>Upload Icon</button>
       </div>
       <div style={{marginBottom:'2em'}}>
-        <h3>SMTP Settings</h3>
-        <p style={{fontSize:'0.9em'}}>Configure how emails are sent for invite links.</p>
+        <h3>Email Settings</h3>
+        <p style={{fontSize:'0.9em'}}>Configure how emails are sent for invite links. You can use Microsoft Graph (app-only) or SMTP (basic/delegated OAuth).</p>
         <div style={{
           marginBottom: '16px',
           border: `2px solid ${branding?.box_border_color || '#007bff'}`,
@@ -234,35 +248,86 @@ export default function BrandingPage() {
           padding: '16px',
           background: branding?.box_bg_color || '#f8faff',
         }}>
+          <label style={{display:'block', marginBottom:'8px'}}>Use Microsoft Graph (recommended for app-only)
+            <input type="checkbox" style={{marginLeft:'8px'}} checked={!!smtp.use_graph_email} onChange={e => setSmtp(v => ({ ...v, use_graph_email: e.target.checked }))} />
+          </label>
+          {smtp.use_graph_email && (
+            <div style={{borderTop:'1px dashed #ccc', paddingTop:'10px', marginTop:'10px'}}>
+              <div style={{fontWeight:'bold', marginBottom:'6px'}}>Graph Settings</div>
+              <div style={{fontSize:'0.85em', opacity:0.8, marginBottom:'6px'}}>Requires an Azure AD app with Application permission Mail.Send (admin consent). Emails are sent as the user below.</div>
+              <label>Tenant ID <input value={smtp.graph_tenant_id || ''} onChange={e => setSmtp(v => ({ ...v, graph_tenant_id: e.target.value }))} /></label><br />
+              <label>Client ID <input value={smtp.graph_client_id || ''} onChange={e => setSmtp(v => ({ ...v, graph_client_id: e.target.value }))} /></label><br />
+              <label>Client Secret <input type="password" value={smtp.graph_client_secret || ''} placeholder={smtp.has_graph_client_secret ? '•••••• (set)' : ''} onChange={e => setSmtp(v => ({ ...v, graph_client_secret: e.target.value }))} /></label>{' '}
+              {smtp.has_graph_client_secret && (
+                <label style={{marginLeft:'8px'}}><input type="checkbox" onChange={e => setSmtp(v => ({ ...v, clear_graph_client_secret: e.target.checked }))} /> Clear client secret</label>
+              )}
+              <br />
+              <label>Send As (user email) <input value={smtp.graph_user || ''} onChange={e => setSmtp(v => ({ ...v, graph_user: e.target.value }))} placeholder="user@domain.com" /></label><br />
+              <label>Authority <input value={smtp.graph_authority || ''} onChange={e => setSmtp(v => ({ ...v, graph_authority: e.target.value }))} placeholder="https://login.microsoftonline.com" /></label>
+            </div>
+          )}
           <label style={{display:'block', marginBottom:'8px'}}>Use OAuth (Exchange Online)
             <input type="checkbox" style={{marginLeft:'8px'}} checked={!!smtp.oauth_enabled} onChange={e => setSmtp(v => ({ ...v, oauth_enabled: e.target.checked }))} />
           </label>
-          <label>SMTP URL <input placeholder="smtp://user:pass@host:port" value={smtp.smtp_url || ''} disabled={smtp.oauth_enabled} onChange={e => setSmtp(v => ({ ...v, smtp_url: e.target.value }))} style={{width:'100%'}} /></label><br />
+          <label>SMTP URL <input placeholder="smtp://user:pass@host:port" value={smtp.smtp_url || ''} disabled={smtp.oauth_enabled || smtp.use_graph_email} onChange={e => setSmtp(v => ({ ...v, smtp_url: e.target.value }))} style={{width:'100%'}} /></label><br />
           <div style={{opacity:0.7, fontSize:'0.85em', margin:'6px 0'}}>Or specify individual fields below (host/port/secure/user/password)</div>
-          <label>Host <input value={smtp.smtp_host || ''} disabled={smtp.oauth_enabled} onChange={e => setSmtp(v => ({ ...v, smtp_host: e.target.value }))} /></label>{' '}
-          <label>Port <input type="number" value={smtp.smtp_port || ''} disabled={smtp.oauth_enabled} onChange={e => setSmtp(v => ({ ...v, smtp_port: e.target.value }))} style={{width:100}} /></label>{' '}
-          <label><input type="checkbox" checked={!!smtp.smtp_secure} disabled={smtp.oauth_enabled} onChange={e => setSmtp(v => ({ ...v, smtp_secure: e.target.checked }))} /> Use TLS (secure)</label><br />
-          <label>Username <input value={smtp.smtp_user || ''} disabled={smtp.oauth_enabled} onChange={e => setSmtp(v => ({ ...v, smtp_user: e.target.value }))} /></label><br />
-          <label>Password <input type="password" value={smtp.smtp_pass || ''} disabled={smtp.oauth_enabled} placeholder={smtp.has_password ? '•••••• (set)' : ''} onChange={e => setSmtp(v => ({ ...v, smtp_pass: e.target.value }))} /></label>{' '}
+          <label>Host <input value={smtp.smtp_host || ''} disabled={smtp.oauth_enabled || smtp.use_graph_email} onChange={e => setSmtp(v => ({ ...v, smtp_host: e.target.value }))} /></label>{' '}
+          <label>Port <input type="number" value={smtp.smtp_port || ''} disabled={smtp.oauth_enabled || smtp.use_graph_email} onChange={e => setSmtp(v => ({ ...v, smtp_port: e.target.value }))} style={{width:100}} /></label>{' '}
+          <label><input type="checkbox" checked={!!smtp.smtp_secure} disabled={smtp.oauth_enabled || smtp.use_graph_email} onChange={e => setSmtp(v => ({ ...v, smtp_secure: e.target.checked }))} /> Use TLS (secure)</label><br />
+          <label>Username <input value={smtp.smtp_user || ''} disabled={smtp.oauth_enabled || smtp.use_graph_email} onChange={e => setSmtp(v => ({ ...v, smtp_user: e.target.value }))} /></label><br />
+          <label>Password <input type="password" value={smtp.smtp_pass || ''} disabled={smtp.oauth_enabled || smtp.use_graph_email} placeholder={smtp.has_password ? '•••••• (set)' : ''} onChange={e => setSmtp(v => ({ ...v, smtp_pass: e.target.value }))} /></label>{' '}
           {!smtp.oauth_enabled && smtp.has_password && (
             <label style={{marginLeft:'8px'}}><input type="checkbox" onChange={e => setSmtp(v => ({ ...v, clear_password: e.target.checked }))} /> Clear saved password</label>
           )}
           <br />
           {smtp.oauth_enabled && (
             <div style={{borderTop:'1px dashed #ccc', paddingTop:'10px', marginTop:'10px'}}>
-              <div style={{fontWeight:'bold', marginBottom:'6px'}}>OAuth (Exchange Online)</div>
-              <div style={{fontSize:'0.85em', opacity:0.8, marginBottom:'6px'}}>Provide your Azure AD app credentials (client credentials flow). The mailbox in "OAuth User" must be accessible to the app. Default scope is outlook.office365.com/.default.</div>
+              <div style={{fontWeight:'bold', marginBottom:'6px'}}>SMTP OAuth (Exchange Online)</div>
+              <div style={{fontSize:'0.85em', opacity:0.8, marginBottom:'6px'}}>For SMTP, use delegated mode (device code sign-in). App-only does not work with SMTP AUTH. If you prefer app-only, use Microsoft Graph above.</div>
+              <label>Mode
+                <select value={smtp.oauth_mode || 'delegated'} onChange={e => setSmtp(v => ({ ...v, oauth_mode: e.target.value }))} style={{marginLeft:'8px'}}>
+                  <option value="delegated">Delegated (device code)</option>
+                  <option value="client-credentials">Client Credentials (not supported for SMTP)</option>
+                </select>
+              </label>
+              <br />
               <label>Tenant ID <input value={smtp.oauth_tenant_id || ''} onChange={e => setSmtp(v => ({ ...v, oauth_tenant_id: e.target.value }))} /></label><br />
               <label>Client ID <input value={smtp.oauth_client_id || ''} onChange={e => setSmtp(v => ({ ...v, oauth_client_id: e.target.value }))} /></label><br />
-              <label>Client Secret <input type="password" value={smtp.oauth_client_secret || ''} placeholder={smtp.has_client_secret ? '•••••• (set)' : ''} onChange={e => setSmtp(v => ({ ...v, oauth_client_secret: e.target.value }))} /></label>{' '}
-              {smtp.has_client_secret && (
-                <label style={{marginLeft:'8px'}}><input type="checkbox" onChange={e => setSmtp(v => ({ ...v, clear_client_secret: e.target.checked }))} /> Clear client secret</label>
+              {smtp.oauth_mode !== 'delegated' && (
+                <>
+                  <label>Client Secret <input type="password" value={smtp.oauth_client_secret || ''} placeholder={smtp.has_client_secret ? '•••••• (set)' : ''} onChange={e => setSmtp(v => ({ ...v, oauth_client_secret: e.target.value }))} /></label>{' '}
+                  {smtp.has_client_secret && (
+                    <label style={{marginLeft:'8px'}}><input type="checkbox" onChange={e => setSmtp(v => ({ ...v, clear_client_secret: e.target.checked }))} /> Clear client secret</label>
+                  )}
+                  <br />
+                </>
               )}
-              <br />
               <label>OAuth User (email) <input value={smtp.oauth_user || ''} onChange={e => setSmtp(v => ({ ...v, oauth_user: e.target.value }))} placeholder="user@domain.com" /></label><br />
-              <label>Scope <input value={smtp.oauth_scope || ''} onChange={e => setSmtp(v => ({ ...v, oauth_scope: e.target.value }))} placeholder="https://outlook.office365.com/.default" /></label><br />
+              <label>Scope <input value={smtp.oauth_scope || ''} onChange={e => setSmtp(v => ({ ...v, oauth_scope: e.target.value }))} placeholder="https://outlook.office365.com/SMTP.Send offline_access openid profile email" /></label><br />
               <label>Authority <input value={smtp.oauth_authority || ''} onChange={e => setSmtp(v => ({ ...v, oauth_authority: e.target.value }))} placeholder="https://login.microsoftonline.com" /></label>
-              {!isOAuthValid && <div style={{color:'#a94442', marginTop:'6px'}}>To use OAuth, please provide Tenant ID, Client ID, Client Secret (or keep existing), and OAuth User.</div>}
+              {!isOAuthValid && <div style={{color:'#a94442', marginTop:'6px'}}>To use OAuth delegated, please provide Tenant ID, Client ID, and OAuth User. Then start device code sign-in.</div>}
+              <div style={{marginTop:'6px'}}>
+                <button
+                  type="button"
+                  style={{background: branding.button_color || '#007bff', color: branding.text_color || '#fff', border: 'none', borderRadius: '4px', padding: '4px 12px'}}
+                  disabled={!isOAuthValid || smtp.oauth_mode !== 'delegated'}
+                  onClick={async () => {
+                    setError(''); setSuccess('');
+                    const token = localStorage.getItem('token');
+                    const res = await apiRequest('/smtp-settings/oauth/device-code', 'POST', {}, token);
+                    if (res && res.success) {
+                      const info = res.device;
+                      if (info) {
+                        setSuccess(`Device code generated. ${info.message || `Go to ${info.verificationUri} and enter code ${info.userCode}`}`);
+                      } else {
+                        setSuccess('Device code flow started. Follow instructions in the terminal/logs.');
+                      }
+                    } else {
+                      setError(res?.error || 'Failed to start device code flow');
+                    }
+                  }}
+                >Start Device Code Sign-in</button>
+              </div>
             </div>
           )}
           <label>From Email <input value={smtp.from_email || ''} onChange={e => setSmtp(v => ({ ...v, from_email: e.target.value }))} placeholder="no-reply@example.com" /></label>
@@ -270,7 +335,7 @@ export default function BrandingPage() {
             <button
               type="button"
               style={{background: branding.button_color || '#007bff', color: branding.text_color || '#fff', border: 'none', borderRadius: '4px', padding: '4px 12px'}}
-              disabled={smtp.oauth_enabled && !isOAuthValid}
+              disabled={(smtp.oauth_enabled && !isOAuthValid) || !canSaveGraph}
               onClick={async () => {
                 setError(''); setSuccess('');
                 const token = localStorage.getItem('token');
@@ -285,6 +350,7 @@ export default function BrandingPage() {
                   ...(smtp.clear_password ? { clear_password: true } : {}),
                   from_email: smtp.from_email,
                   oauth_enabled: smtp.oauth_enabled,
+                  oauth_mode: smtp.oauth_mode,
                   oauth_tenant_id: smtp.oauth_tenant_id,
                   oauth_client_id: smtp.oauth_client_id,
                   oauth_user: smtp.oauth_user,
@@ -292,6 +358,13 @@ export default function BrandingPage() {
                   oauth_authority: smtp.oauth_authority,
                   ...(smtp.oauth_client_secret ? { oauth_client_secret: smtp.oauth_client_secret } : {}),
                   ...(smtp.clear_client_secret ? { clear_client_secret: true } : {}),
+                  use_graph_email: smtp.use_graph_email,
+                  graph_tenant_id: smtp.graph_tenant_id,
+                  graph_client_id: smtp.graph_client_id,
+                  graph_user: smtp.graph_user,
+                  graph_authority: smtp.graph_authority,
+                  ...(smtp.graph_client_secret ? { graph_client_secret: smtp.graph_client_secret } : {}),
+                  ...(smtp.clear_graph_client_secret ? { clear_graph_client_secret: true } : {}),
                 };
                 const res = await apiRequest('/smtp-settings', 'PUT', payload, token);
                 if (res && !res.error) {
@@ -300,10 +373,13 @@ export default function BrandingPage() {
                     ...v,
                     smtp_pass: '',
                     oauth_client_secret: '',
+                    graph_client_secret: '',
                     has_password: smtp.clear_password ? false : (v.has_password || !!payload.smtp_pass),
                     has_client_secret: smtp.clear_client_secret ? false : (v.has_client_secret || !!payload.oauth_client_secret),
+                    has_graph_client_secret: smtp.clear_graph_client_secret ? false : (v.has_graph_client_secret || !!payload.graph_client_secret),
                     clear_password: false,
                     clear_client_secret: false,
+                    clear_graph_client_secret: false,
                   }));
                 } else {
                   setError(res.error || 'Failed to save SMTP settings');
@@ -321,8 +397,13 @@ export default function BrandingPage() {
                   const token = localStorage.getItem('token');
                   const res = await apiRequest('/smtp-settings/verify-oauth', 'POST', {}, token);
                   if (res && !res.error && res.success) {
-                    const exp = res.expiresOn ? new Date(res.expiresOn) : null;
-                    setSuccess(`OAuth token acquired successfully${exp ? ` (expires ${exp.toLocaleString()})` : ''}.`);
+                    if (res.mode === 'delegated') {
+                      setSuccess(`Delegated OAuth is ready${res.username ? ` for ${res.username}` : ''}.`);
+                    } else if (res.mode === 'graph') {
+                      setSuccess('Graph app-only auth is valid.');
+                    } else {
+                      setSuccess('OAuth verified.');
+                    }
                   } else {
                     const msg = (res && res.error) || 'OAuth verification failed';
                     const det = [res?.details, res?.code, res?.suberror, res?.correlationId].filter(Boolean).join(' | ');
@@ -336,7 +417,7 @@ export default function BrandingPage() {
               <button
                 type="button"
                 style={{background: branding.button_color || '#007bff', color: branding.text_color || '#fff', border: 'none', borderRadius: '4px', padding: '4px 12px'}}
-                disabled={smtp.oauth_enabled && !isOAuthValid}
+                disabled={(smtp.oauth_enabled && !isOAuthValid)}
                 onClick={async () => {
                   setError(''); setSuccess('');
                   if (smtp.oauth_enabled && !isOAuthValid) {

--- a/frontend/src/pages/MemberManagementPage.jsx
+++ b/frontend/src/pages/MemberManagementPage.jsx
@@ -182,9 +182,9 @@ export default function MemberManagementPage({ branding }) {
 }}>
         <h4>Registration Invites</h4>
         <form onSubmit={handleCreateInvites} style={{display:'flex', gap:'8px', flexWrap:'wrap', alignItems:'center'}}>
-          <input type="email" placeholder="Invitee Email (optional)" value={inviteEmail} onChange={e => setInviteEmail(e.target.value)} />
-          <input type="number" min="1" max="100" placeholder="Count" value={inviteCount} onChange={e => setInviteCount(e.target.value)} style={{width:'90px'}} />
-          <input type="number" min="1" max="8760" placeholder="Expires in hours" value={inviteHours} onChange={e => setInviteHours(e.target.value)} style={{width:'140px'}} />
+          <label><input type="email" placeholder="Invitee Email" value={inviteEmail} onChange={e => setInviteEmail(e.target.value)} />Email</label>
+          <label><input type="number" min="1" max="100" placeholder="Count" value={inviteCount} onChange={e => setInviteCount(e.target.value)} style={{width:'90px'}} />Count</label>
+          <label><input type="number" min="1" max="8760" placeholder="Expires in hours" value={inviteHours} onChange={e => setInviteHours(e.target.value)} style={{width:'140px'}} />Expires in hours</label>
           <button type="submit" style={{background: (branding?.button_color || '#007bff'), color: (branding?.text_color || '#fff'), border: 'none', borderRadius: '4px', padding: '4px 12px'}}>Create</button>
         </form>
         <div style={{marginTop:'12px', maxHeight:'220px', overflowY:'auto'}}>


### PR DESCRIPTION
- Introduced a new email service module to manage email sending via SMTP and Microsoft Graph.
- Updated backend routes to utilize the new email service for sending registration invites and test emails.
- Removed legacy OAuth handling from SMTP transport creation, delegating it to the new email service.
- Enhanced frontend branding page to configure email settings for both SMTP and Microsoft Graph, including OAuth modes.
- Added support for device code flow for OAuth in the backend and corresponding UI elements in the frontend.
- Improved error handling and validation for email settings in the frontend.